### PR TITLE
add checks for option particleEffects before trying to resolve the Effect enum; should solve #48

### DIFF
--- a/src/com/jcdesimp/landlord/commands/Claim.java
+++ b/src/com/jcdesimp/landlord/commands/Claim.java
@@ -127,7 +127,9 @@ public class Claim implements LandlordCommand {
                 }
             }
             Landlord.getInstance().getDatabase().save(land);
-            land.highlightLand(player, Effect.HAPPY_VILLAGER);
+            if(plugin.getConfig().getBoolean("options.particleEffects")){
+                land.highlightLand(player, Effect.HAPPY_VILLAGER);
+            }
             sender.sendMessage(
                     ChatColor.GREEN + "Successfully claimed chunk (" + currChunk.getX() + ", " +
                             currChunk.getZ() + ") in world \'" + currChunk.getWorld().getName() + "\'." );  //mess

--- a/src/com/jcdesimp/landlord/commands/Unclaim.java
+++ b/src/com/jcdesimp/landlord/commands/Unclaim.java
@@ -112,7 +112,9 @@ public class Unclaim implements LandlordCommand {
                 player.sendMessage(ChatColor.YELLOW+"Unclaimed " + getOfflinePlayer(dbLand.ownerUUID()).getName() + "'s land.");    //mess
             }
             plugin.getDatabase().delete(dbLand);
-            dbLand.highlightLand(player, Effect.WITCH_MAGIC);
+            if(plugin.getConfig().getBoolean("options.particleEffects")){
+                dbLand.highlightLand(player, Effect.WITCH_MAGIC);
+            }
 
             sender.sendMessage(
                     ChatColor.YELLOW + "Successfully unclaimed chunk (" + currChunk.getX() + ", " +         //mess

--- a/src/com/jcdesimp/landlord/landManagement/LandManagerView.java
+++ b/src/com/jcdesimp/landlord/landManagement/LandManagerView.java
@@ -205,7 +205,9 @@ public class LandManagerView implements Listener {
             if(Landlord.getInstance().getConfig().getBoolean("options.soundEffects",true)){
                 player.playSound(player.getLocation(),Sound.FIZZ,10,10);
             }
-            mLand.highlightLand(player, Effect.LAVADRIP);
+            if(plugin.getConfig().getBoolean("options.particleEffects")){
+                mLand.highlightLand(player, Effect.LAVADRIP);
+            }
             //InventoryCloseEvent.getHandlerList().unregister(this);
             Landlord.getInstance().getManageViewManager().NoCloseDeactivateView(player);
             HandlerList.unregisterAll(this);


### PR DESCRIPTION
See http://dev.bukkit.org/bukkit-plugins/landlord/tickets/48-internal-error-when-using-any-landlord-command-no-world/ for more details.